### PR TITLE
Fix/internship offer address when editing

### DIFF
--- a/app/front_assets/components/inputs/AddressInput.jsx
+++ b/app/front_assets/components/inputs/AddressInput.jsx
@@ -182,25 +182,6 @@ export default function AddressInput({
             />
           </div>
         </div>
-        <div className="col-sm-4">
-          <div className="form-group">
-            <label htmlFor={`${resourceName}_city`}>
-              Ville
-              <abbr title="(obligatoire)" aria-hidden="true">
-                *
-              </abbr>
-            </label>
-            <input
-              className="form-control"
-              required="required"
-              value={city}
-              type="text"
-              readOnly
-              name={`${resourceName}[city]`}
-              id={`${resourceName}_city`}
-            />
-          </div>
-        </div>
         <div className="col-sm-2">
           <div className="form-group">
             <label htmlFor={`${resourceName}_zipcode`}>
@@ -217,6 +198,25 @@ export default function AddressInput({
               name={`${resourceName}[zipcode]`}
               id={`${resourceName}_zipcode`}
               readOnly
+            />
+          </div>
+        </div>
+        <div className="col-sm-4">
+          <div className="form-group">
+            <label htmlFor={`${resourceName}_city`}>
+              Ville
+              <abbr title="(obligatoire)" aria-hidden="true">
+                *
+              </abbr>
+            </label>
+            <input
+              className="form-control"
+              required="required"
+              value={city}
+              type="text"
+              readOnly
+              name={`${resourceName}[city]`}
+              id={`${resourceName}_city`}
             />
           </div>
         </div>

--- a/app/models/concerns/nearbyable.rb
+++ b/app/models/concerns/nearbyable.rb
@@ -63,9 +63,9 @@ module Nearbyable
     def formatted_autocomplete_address
       [
         street,
-        city,
-        zipcode
-      ].compact.uniq.join(', ')
+        zipcode,
+        city
+      ].compact.uniq.join(' ')
     end
   end
 end

--- a/app/views/dashboard/internship_offers/_form.html.slim
+++ b/app/views/dashboard/internship_offers/_form.html.slim
@@ -106,7 +106,7 @@
                                 currentCity: @internship_offer.city,
                                 currentZipcode: @internship_offer.zipcode,
                                 currentLatitude: @internship_offer.coordinates.try(:lat).try(:to_f),
-                                currentLongitude: @internship_offer.coordinates.try(:lng).try(:to_f),
+                                currentLongitude: @internship_offer.coordinates.try(:lon).try(:to_f),
                                 currentFullAddress: @internship_offer.formatted_autocomplete_address})
 
     .form-group data-controller='maxlength-input' data-maxlength-input-limit=InternshipOffer::EMPLOYER_DESCRIPTION_MAX_CHAR_COUNT


### PR DESCRIPTION
En plus du correctif, j'ai pris la liberté d'intervertir la position des champs code postal et ville pour être cohérent avec le retour affichée par l'api qui montre l'ordre zipcode city
