### PR TITLE
Reconfirmation stand by phone account

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,9 +9,16 @@ module Users
 
     def create
       if by_phone? && fetch_user_by_phone.try(:valid_password?, params[:user][:password])
-        sign_in(fetch_user_by_phone)
-        redirect_to root_path
-        return
+        user = fetch_user_by_phone
+        if user.confirmed?
+          sign_in(user)
+          redirect_to root_path
+          return
+        else
+          user.send_sms_token
+          redirect_to users_registrations_phone_standby_path(phone: safe_phone_param)
+          return
+        end
       end
       super
     end

--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -32,6 +32,17 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_select '#alert-warning #alert-text', text: 'Un message d’activation vous a été envoyé par courrier électronique. Veuillez suivre les instructions qu’il contient.', count: 1
   end
 
+  test 'POST session not confirmed by phone redirect to confirmation token page' do
+    pwd = 'okokok'
+    student = create(:student, password: pwd, phone: '+330611223344', confirmed_at: nil)
+    post user_session_path(params: { user: { channel: 'phone',
+                                             phone: student.phone,
+                                             password: pwd } })
+    assert_response :found
+    follow_redirect!
+    assert_select 'h1', 'Encore une petite étape...'
+  end
+
   test 'POST session with phone' do
     pwd = 'okokok'
     phone = '+330637607756'


### PR DESCRIPTION
Bug Fix :
When a user registred by phone leave the token confirmation page, it should be redirect to this page when trying to log in.